### PR TITLE
Remove outdated annotations about Webpack 2 and 3 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,6 @@ function(module, exports) {
 
 ## Known Limitations
 
-Currently this only works with Webpack 1.x. Webpack 2 support is at the top the
-our to-do list.
-
 You cannot reference class names that are not valid Elm record keys.
 
 [css-loader]: https://www.npmjs.com/package/css-loader


### PR DESCRIPTION
Thanks for a great library!
It seems v1.1.2 now supports Webpack 2 and 3, so I've removed confusing descriptions about Webpack supports on README.