### PR TITLE
Include `_` in moduleNameCapture

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const loader = function(source, inputSourceMap) {
         config.tagger,
       ].join('$'),
     escapedTaggerName = taggerName.replace(/\$/g, '\\$'),
-    moduleNameCapture = "'([a-zA-Z-./]+)'",
+    moduleNameCapture = "'([a-zA-Z-_./]+)'",
     expectedClassRules = "{[a-zA-Z0-9:, ']*}";
 
   const regexp = regexpForFunctionCall('A2', [


### PR DESCRIPTION
If you have an `_` in a pathname, the CSS module is silently skipped.