### PR TITLE
Allow '$' in class rules regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const loader = function(source, inputSourceMap) {
       ].join('$'),
     escapedTaggerName = taggerName.replace(/\$/g, '\\$'),
     moduleNameCapture = "'([a-zA-Z-_./]+)'",
-    expectedClassRules = "{[a-zA-Z0-9:, ']*}";
+    expectedClassRules = "{[a-zA-Z0-9:$, ']*}";
 
   const regexp = regexpForFunctionCall('A2', [
     escapedTaggerName,


### PR DESCRIPTION
Catches the situation where you have a css class called 'default' and that is escaped by something in the pipeline to be '$default'.